### PR TITLE
Increase the limit to not kill some normal running tasks.

### DIFF
--- a/openradar/tasks.py
+++ b/openradar/tasks.py
@@ -29,7 +29,7 @@ os.environ['PYTHONPATH'] = ':'.join(sys.path)
 app = celery.Celery()
 app.conf.update(
     BROKER_URL=config.CELERY_BROKER_URL,
-    CELERYD_TASK_TIME_LIMIT=300,
+    CELERYD_TASK_TIME_LIMIT=600,
 )
 
 


### PR DESCRIPTION
We had killed tasks twice per day in the last week. That's a bit too strict. According to the logs they were doing well until killed. Let's double the limit.