### PR TITLE
changes to products.py to add calibration rainstations to metadata

### DIFF
--- a/openradar/config.py
+++ b/openradar/config.py
@@ -129,6 +129,9 @@ DELIVERY_TIMES = (
     ('u', datetime.timedelta(days=30)),
 )
 
+# attributes for rainstations to store in h5 file metadata
+RAINSTATION_METADATA = ['station_id' , 'lat', 'lon', 'measurement']
+
 # Delays for waiting-for-files
 WAIT_SLEEP_TIME = 10  # Seconds
 WAIT_EXPIRE_DELTA = datetime.timedelta(minutes=3)

--- a/openradar/config.py
+++ b/openradar/config.py
@@ -129,9 +129,6 @@ DELIVERY_TIMES = (
     ('u', datetime.timedelta(days=30)),
 )
 
-# attributes for rainstations to store in h5 file metadata
-RAINSTATION_METADATA = ['station_id' , 'lat', 'lon', 'measurement']
-
 # Delays for waiting-for-files
 WAIT_SLEEP_TIME = 10  # Seconds
 WAIT_EXPIRE_DELTA = datetime.timedelta(minutes=3)

--- a/openradar/interpolation.py
+++ b/openradar/interpolation.py
@@ -96,7 +96,6 @@ class DataLoader(object):
                 measurement=-999. if d['value'] is None else d['value'],
             ))
 
-
     def stations_dummies(self):
         data = self.stationsdata
         xcol = data[0].index('X')

--- a/openradar/interpolation.py
+++ b/openradar/interpolation.py
@@ -28,16 +28,6 @@ class RainStation(object):
         self.klasse = int(klasse)
         self.measurement = measurement
 
-    def __repr__(self):
-        return ('<RainStation {self.station_id:} '
-        'measurement: {self.measurement: .3f} mm>').format(
-        self=self
-        )
-
-    def as_dict(self, attrs):
-        """return dictionary of (selected) attributes"""
-        return {a: getattr(self, a) for a in attrs}
-
 
 class DataLoader(object):
     '''
@@ -106,12 +96,6 @@ class DataLoader(object):
                 measurement=-999. if d['value'] is None else d['value'],
             ))
 
-    def get_rainstation_data(self, attrs, skip_na=True):
-        """ Return rainstations as dictionaries, optionally skipping nodata. """
-        for station in self.rainstations:
-            if skip_na and station.measurement == -999.:
-                continue
-            yield station.as_dict(attrs=attrs)
 
     def stations_dummies(self):
         data = self.stationsdata

--- a/openradar/interpolation.py
+++ b/openradar/interpolation.py
@@ -28,6 +28,12 @@ class RainStation(object):
         self.klasse = int(klasse)
         self.measurement = measurement
 
+    def as_dict(self, attrs=None):
+        """return dictionary of (selected) attributes"""
+        if attrs is None:
+            attrs = [a for a in dir(attrs) if not a.startswith('__')]
+        return {a: getattr(self, a) for a in attrs}
+
 
 class DataLoader(object):
     '''
@@ -95,6 +101,13 @@ class DataLoader(object):
                 klasse=0,
                 measurement=-999. if d['value'] is None else d['value'],
             ))
+
+    def get_rainstation_data(self, attrs, skip_na=True):
+        """ Return rainstations as dictionaries, optionally skipping nodata. """
+        for station in self.rainstations:
+            if skip_na and station.measurement == -999.:
+                continue
+            yield station.as_dict(attrs=attrs)
 
     def stations_dummies(self):
         data = self.stationsdata

--- a/openradar/interpolation.py
+++ b/openradar/interpolation.py
@@ -28,10 +28,14 @@ class RainStation(object):
         self.klasse = int(klasse)
         self.measurement = measurement
 
-    def as_dict(self, attrs=None):
+    def __repr__(self):
+        return ('<RainStation {self.station_id:} '
+        'measurement: {self.measurement: .3f} mm>').format(
+        self=self
+        )
+
+    def as_dict(self, attrs):
         """return dictionary of (selected) attributes"""
-        if attrs is None:
-            attrs = [a for a in dir(attrs) if not a.startswith('__')]
         return {a: getattr(self, a) for a in attrs}
 
 

--- a/openradar/interpolation.py
+++ b/openradar/interpolation.py
@@ -90,8 +90,8 @@ class DataLoader(object):
         for d in dbdata:
             self.rainstations.append(RainStation(
                 station_id=d['id'],
-                lat=d['coords'][0],
-                lon=d['coords'][1],
+                lat=d['coords'][1],
+                lon=d['coords'][0],
                 klasse=0,
                 measurement=-999. if d['value'] is None else d['value'],
             ))
@@ -130,7 +130,7 @@ class Interpolator(object):
         Seperates the measurements location and data. Also requests the classes
         of each weather stations. These are now by default set to 1.
         '''
-        xy = numpy.array([[i.lat, i.lon]
+        xy = numpy.array([[i.lon, i.lat]
                           for i in self.dataloader.rainstations])
         z = numpy.array([i.measurement for i in self.dataloader.rainstations])
         klasse = numpy.array([i.klasse for i in self.dataloader.rainstations])
@@ -145,7 +145,7 @@ class Interpolator(object):
         For correction field calculation dummies are needed to fill the gaps.
         '''
         self.dataloader.stations_dummies()
-        xyz = numpy.ma.array([[i.lat, i.lon, i.measurement]
+        xyz = numpy.ma.array([[i.lon, i.lat, i.measurement]
                               for i in self.dataloader.stations])
         return xyz.T
 

--- a/openradar/products.py
+++ b/openradar/products.py
@@ -431,17 +431,21 @@ class CalibratedProduct(object):
         try:
             dataloader.processdata()
             stations_count = len(dataloader.rainstations)
-            station_attrs = config.RAINSTATION_METADATA
-            get_station_data = dataloader.get_rainstation_data(station_attrs)
-            stations_data = [r for r in get_station_data]
-            data_count = len(stations_data)
+            cal_stations = [rs for rs in dataloader.rainstations
+                if not rs.measurement == -999.]
+            data_count = len(cal_stations)
+            cal_station_ids = [rs.station_id for rs in cal_stations]
+            cal_station_coords = [(rs.lat, rs.lon) for rs in cal_stations]
+            cal_station_measurements = [rs.measurement for rs in cal_stations]
             logging.info('{} out of {} gauges have data for {}.'.format(
                 data_count, stations_count, dataloader.date)
             )
         except:
             logging.exception('Exception during calibration preprocessing:')
             stations_count = 0
-            stations_data = []
+            cal_station_ids = []
+            cal_station_coords = []
+            cal_station_measurements = []
             data_count = 0
         interpolator = Interpolator(dataloader)
 
@@ -496,7 +500,9 @@ class CalibratedProduct(object):
         dataloader.dataset.close()
         # Append metadata about the calibration
         self.metadata.update(dict(
-            cal_stations_data=stations_data,
+            cal_station_ids=cal_station_ids,
+            cal_station_coords=cal_station_coords,
+            cal_station_measurements=cal_station_measurements,
             cal_stations_count=stations_count,
             cal_data_count=data_count,
             cal_method=calibration_method,

--- a/openradar/products.py
+++ b/openradar/products.py
@@ -434,7 +434,8 @@ class CalibratedProduct(object):
             cal_stations = [rs for rs in dataloader.rainstations
                 if not rs.measurement == -999.]
             data_count = len(cal_stations)
-            cal_station_ids = [rs.station_id for rs in cal_stations]
+            cal_station_ids = np.array([rs.station_id for rs in cal_stations],
+                dtype='S20')
             cal_station_coords = [(rs.lat, rs.lon) for rs in cal_stations]
             cal_station_measurements = [rs.measurement for rs in cal_stations]
             logging.info('{} out of {} gauges have data for {}.'.format(

--- a/openradar/products.py
+++ b/openradar/products.py
@@ -441,6 +441,7 @@ class CalibratedProduct(object):
         except:
             logging.exception('Exception during calibration preprocessing:')
             stations_count = 0
+            stations_data = []
             data_count = 0
         interpolator = Interpolator(dataloader)
 

--- a/openradar/products.py
+++ b/openradar/products.py
@@ -435,8 +435,8 @@ class CalibratedProduct(object):
                 if not rs.measurement == -999.]
             data_count = len(cal_stations)
             cal_station_ids = np.array([rs.station_id for rs in cal_stations],
-                dtype='S50')
-            cal_station_coords = [(rs.lat, rs.lon) for rs in cal_stations]
+                dtype='S20')
+            cal_station_coords = [(rs.lon, rs.lat) for rs in cal_stations]
             cal_station_measurements = [rs.measurement for rs in cal_stations]
             logging.info('{} out of {} gauges have data for {}.'.format(
                 data_count, stations_count, dataloader.date)

--- a/openradar/products.py
+++ b/openradar/products.py
@@ -431,9 +431,10 @@ class CalibratedProduct(object):
         try:
             dataloader.processdata()
             stations_count = len(dataloader.rainstations)
-            data_count = len([r
-                              for r in dataloader.rainstations
-                              if r.measurement != -999])
+            station_attrs = config.RAINSTATION_METADATA
+            get_station_data = dataloader.get_rainstation_data(station_attrs)
+            stations_data = [r for r in get_station_data]
+            data_count = len(stations_data)
             logging.info('{} out of {} gauges have data for {}.'.format(
                 data_count, stations_count, dataloader.date)
             )
@@ -494,6 +495,7 @@ class CalibratedProduct(object):
         dataloader.dataset.close()
         # Append metadata about the calibration
         self.metadata.update(dict(
+            cal_stations_data=stations_data,
             cal_stations_count=stations_count,
             cal_data_count=data_count,
             cal_method=calibration_method,

--- a/openradar/products.py
+++ b/openradar/products.py
@@ -435,7 +435,7 @@ class CalibratedProduct(object):
                 if not rs.measurement == -999.]
             data_count = len(cal_stations)
             cal_station_ids = np.array([rs.station_id for rs in cal_stations],
-                dtype='S20')
+                dtype='S50')
             cal_station_coords = [(rs.lat, rs.lon) for rs in cal_stations]
             cal_station_measurements = [rs.measurement for rs in cal_stations]
             logging.info('{} out of {} gauges have data for {}.'.format(


### PR DESCRIPTION
Added the attributes cal_station_ids, cal_station_coords, cal_station_measurements to h5 metadata. Tested for the calibrated product of 2014-01-01 01:00:00 (After, timeframe=h). Tested by reading the hdf5 attributes of the calibrated product using h5py.




